### PR TITLE
MOD: should return empty list when hscan,zscan,sscan is empty

### DIFF
--- a/tests/functional/hash_test.py
+++ b/tests/functional/hash_test.py
@@ -158,11 +158,13 @@ def test_hscan():
     conn = get_redis_conn()
     key = "test_hscan"
     ret = conn.execute_command("HSCAN " + key + " 0")
-    assert (ret == ['0', []])
+    if ret != ["0", []]:
+        raise ValueError('ret is not ["0", []]: ' + ret)
     ret = conn.hset(key, 'a', 1.3)
     assert (ret == 1)
     ret = conn.execute_command("HSCAN " + key + " 0")
-    assert (ret == ['0', ['a', '1.3']])
+    if ret != ['0', ['a', '1.3']]:
+        raise ValueError('ret illegal: ' + ret)
 
     ret = conn.delete(key)
     assert (ret == 1)

--- a/tests/functional/hash_test.py
+++ b/tests/functional/hash_test.py
@@ -157,10 +157,12 @@ def test_hgetall():
 def test_hscan():
     conn = get_redis_conn()
     key = "test_hscan"
+    ret = conn.execute_command("HSCAN " + key + " 0")
+    assert (ret == ['0', []])
     ret = conn.hset(key, 'a', 1.3)
     assert (ret == 1)
     ret = conn.execute_command("HSCAN " + key + " 0")
-    assert (ret == ['a', ['a', '1.3']])
+    assert (ret == ['0', ['a', '1.3']])
 
     ret = conn.delete(key)
     assert (ret == 1)

--- a/tests/functional/key_test.py
+++ b/tests/functional/key_test.py
@@ -41,7 +41,8 @@ def test_type():
     ret = conn.type(sortedint_key)
     assert(ret == "sortedint")
     ret = conn.delete(string_key, hash_key, list_key, set_key, zset_key, bitmap_key, sortedint_key)
-    assert(ret == 7)
+    if ret != 7:
+        raise ValueError('ret is not 7: ' + ret)
 
 def test_expire():
     key = "test_expire"
@@ -301,13 +302,15 @@ def test_scan():
     key = "test_scan"
     conn = get_redis_conn()
     ret = conn.execute_command("SCAN" + " 0")
-    assert (ret == ["0", []])
+    if ret != ["0", []]:
+        raise ValueError('ret is not ["0", []]: ' + ret)
 
     ret = conn.set(key, "bar")
     assert(ret)
 
     ret = conn.execute_command("SCAN" + " 0")
-    assert (ret == ["0", [key]])
+    if ret != ["0", [key]]:
+        raise ValueError('ret is not ["0", [' + key + ']]: ' + ret)
 
     ret = conn.delete(key)
     assert (ret == 1)

--- a/tests/functional/key_test.py
+++ b/tests/functional/key_test.py
@@ -41,7 +41,7 @@ def test_type():
     ret = conn.type(sortedint_key)
     assert(ret == "sortedint")
     ret = conn.delete(string_key, hash_key, list_key, set_key, zset_key, bitmap_key, sortedint_key)
-    assert(ret == 5)
+    assert(ret == 7)
 
 def test_expire():
     key = "test_expire"
@@ -300,11 +300,14 @@ def test_randomkey():
 def test_scan():
     key = "test_scan"
     conn = get_redis_conn()
+    ret = conn.execute_command("SCAN" + " 0")
+    assert (ret == ["0", []])
+
     ret = conn.set(key, "bar")
     assert(ret)
 
     ret = conn.execute_command("SCAN" + " 0")
-    assert (ret == [key, [key]])
+    assert (ret == ["0", [key]])
 
     ret = conn.delete(key)
     assert (ret == 1)

--- a/tests/functional/set_test.py
+++ b/tests/functional/set_test.py
@@ -190,10 +190,12 @@ def test_sscan():
     conn = get_redis_conn()
     key = "test_sscan"
     ret = conn.execute_command("SSCAN " + key + " 0")
-    assert (ret == ['0', []])
+    if ret != ["0", []]:
+        raise ValueError('ret is not ["0", []]: ' + ret)
     ret = conn.sadd(key, 'a')
     ret = conn.execute_command("SSCAN " + key + " 0")
-    assert (ret == ['0', ['a']])
+    if ret != ['0', ['a']]:
+        raise ValueError('ret illegal: ' + ret)
 
     ret = conn.delete(key)
     assert(ret == 1)

--- a/tests/functional/set_test.py
+++ b/tests/functional/set_test.py
@@ -189,9 +189,11 @@ def test_sunionstore():
 def test_sscan():
     conn = get_redis_conn()
     key = "test_sscan"
+    ret = conn.execute_command("SSCAN " + key + " 0")
+    assert (ret == ['0', []])
     ret = conn.sadd(key, 'a')
     ret = conn.execute_command("SSCAN " + key + " 0")
-    assert (ret == ['a', ['a']])
+    assert (ret == ['0', ['a']])
 
     ret = conn.delete(key)
     assert(ret == 1)

--- a/tests/functional/zset_test.py
+++ b/tests/functional/zset_test.py
@@ -295,10 +295,12 @@ def test_zremrangebylex():
 def test_zscan():
     conn = get_redis_conn()
     key = "test_zscan"
+    ret = conn.execute_command("ZSCAN " + key + " 0")
+    assert (ret == ['0', []])
     ret = conn.zadd(key, 'a', 1.3)
     assert (ret == 1)
     ret = conn.execute_command("ZSCAN " + key + " 0")
-    assert (ret == ['a', ['a', '1.300000']])
+    assert (ret == ['0', ['a', '1.300000']])
 
     ret = conn.delete(key)
     assert (ret == 1)

--- a/tests/functional/zset_test.py
+++ b/tests/functional/zset_test.py
@@ -296,11 +296,13 @@ def test_zscan():
     conn = get_redis_conn()
     key = "test_zscan"
     ret = conn.execute_command("ZSCAN " + key + " 0")
-    assert (ret == ['0', []])
+    if ret != ["0", []]:
+        raise ValueError('ret is not ["0", []]: ' + ret)
     ret = conn.zadd(key, 'a', 1.3)
     assert (ret == 1)
     ret = conn.execute_command("ZSCAN " + key + " 0")
-    assert (ret == ['0', ['a', '1.300000']])
+    if ret != ['0', ['a', '1.300000']]:
+        raise ValueError('ret illegal: ' + ret)
 
     ret = conn.delete(key)
     assert (ret == 1)


### PR DESCRIPTION
MOD: return cursor "0" when there is no more key left