### PR TITLE
FIX: add BEV_OPT_THREADSAFE option (monitor cmd will coredump when…

### DIFF
--- a/src/worker.cc
+++ b/src/worker.cc
@@ -75,7 +75,10 @@ void Worker::newConnection(evconnlistener *listener, evutil_socket_t fd,
     return;
   }
   event_base *base = evconnlistener_get_base(listener);
-  bufferevent *bev = bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
+  bufferevent *bev = bufferevent_socket_new(base,
+                                            fd,
+                                            BEV_OPT_CLOSE_ON_FREE | BEV_OPT_THREADSAFE | BEV_OPT_DEFER_CALLBACKS
+                                                | BEV_OPT_UNLOCK_CALLBACKS);
   auto conn = new Redis::Connection(bev, worker);
   bufferevent_setcb(bev, Redis::Connection::OnRead, Redis::Connection::OnWrite,
                     Redis::Connection::OnEvent, conn);


### PR DESCRIPTION
… evbuffer_add and evbuffer_drain concurrently in multi thread)