### PR TITLE
improve the compaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ configure_file(src/version.h.in ${PROJECT_BINARY_DIR}/version.h)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
 endif()
-add_executable(kvrocks)
+add_executable(kvrocks )
 target_compile_features(kvrocks PRIVATE cxx_std_11)
 target_compile_options(kvrocks PRIVATE -Wall -Wpedantic -g -Wsign-compare -Wreturn-type -fno-omit-frame-pointer)
 option(ENABLE_ASAN "enable ASAN santinizer" OFF)
@@ -138,6 +138,10 @@ target_sources(kvrocks PRIVATE
         src/event_listener.cc
         src/log_collector.h
         src/log_collector.cc
+        src/table_properties_collector.cc
+        src/table_properties_collector.h
+        src/compaction_checker.cc
+        src/compaction_checker.h
         )
 
 # kvrocks2redis sync tool
@@ -228,6 +232,10 @@ target_sources(kvrocks2redis PRIVATE
         src/event_listener.cc
         src/log_collector.h
         src/log_collector.cc
+        src/table_properties_collector.cc
+        src/table_properties_collector.h
+        src/compaction_checker.cc
+        src/compaction_checker.h
         tools/kvrocks2redis/config.cc
         tools/kvrocks2redis/config.h
         tools/kvrocks2redis/main.cc
@@ -312,6 +320,10 @@ add_executable(unittest
         src/redis_db.h
         src/log_collector.h
         src/log_collector.cc
+        src/table_properties_collector.cc
+        src/table_properties_collector.h
+        src/compaction_checker.cc
+        src/compaction_checker.h
         tests/main.cc
         tests/test_base.h
         tests/t_string_test.cc

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -228,7 +228,12 @@ supervised no
 # time expression format is the same as crontab(currently only support * and int)
 # e.g. compact-cron 0 3 * * * 0 4 * * *
 # would compact the db at 3am and 4am everyday
-compact-cron 0 3 * * *
+# compact-cron 0 3 * * *
+
+# The hour range that compaction checker would be active
+# e.g. compaction-checker-range 2-8 means compaction checker would be worker between
+# 2am and 8am every day.
+compaction-checker-range 0-24
 
 # Bgsave scheduler, auto bgsave at schedule time
 # time expression format is the same as crontab(currently only support * and int)

--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -231,9 +231,9 @@ supervised no
 # compact-cron 0 3 * * *
 
 # The hour range that compaction checker would be active
-# e.g. compaction-checker-range 2-8 means compaction checker would be worker between
-# 2am and 8am every day.
-compaction-checker-range 0-24
+# e.g. compaction-checker-range 0-7 means compaction checker would be worker between
+# 0-7am every day.
+compaction-checker-range 0-7
 
 # Bgsave scheduler, auto bgsave at schedule time
 # time expression format is the same as crontab(currently only support * and int)

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,8 @@ SHARED_OBJS= compact_filter.o config.o cron.o encoding.o event_listener.o lock_m
 			   log_collector.o redis_bitmap.o redis_bitmap_string.o redis_cmd.o redis_connection.o redis_db.o \
 			   redis_hash.o redis_list.o redis_metadata.o redis_pubsub.o redis_reply.o \
 			   redis_request.o redis_set.o redis_string.o redis_zset.o redis_geo.o redis_slot.o replication.o \
-			   server.o stats.o storage.o task_runner.o util.o geohash.o worker.o redis_sortedint.o
+			   server.o stats.o storage.o task_runner.o util.o geohash.o worker.o redis_sortedint.o \
+			   compaction_checker.o table_properties_collector.o
 KVROCKS_OBJS= $(SHARED_OBJS) main.o
 
 UNITTEST_OBJS= $(SHARED_OBJS) ../tests/main.o ../tests/t_metadata_test.o ../tests/compact_test.o \

--- a/src/compaction_checker.cc
+++ b/src/compaction_checker.cc
@@ -1,0 +1,90 @@
+#include "compaction_checker.h"
+#include <glog/logging.h>
+#include "storage.h"
+
+void CompactionChecker::CompactPubsubAndSlotFiles() {
+  rocksdb::CompactRangeOptions compact_opts;
+  compact_opts.change_level = true;
+  std::vector<std::string> cf_names = {Engine::kPubSubColumnFamilyName};
+  if (storage_->CodisEnabled()) {
+    cf_names.emplace_back(Engine::kSlotColumnFamilyName);
+    cf_names.emplace_back(Engine::kSlotMetadataColumnFamilyName);
+  }
+  for (const auto &cf_name : cf_names) {
+    LOG(INFO) << "[compaction checker] Start the compact the column family: " << cf_name;
+    auto cf_handle = storage_->GetCFHandle(cf_name);
+    auto s = storage_->GetDB()->CompactRange(compact_opts, cf_handle, nullptr, nullptr);
+    LOG(INFO) << "[compaction checker] Compact the column family: "<< cf_name <<" finished, result: " << s.ToString();
+  }
+}
+
+void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
+  rocksdb::TablePropertiesCollection props;
+  rocksdb::ColumnFamilyHandle *cf = storage_->GetCFHandle(cf_name);
+
+  LOG(INFO) << "";
+  auto s = storage_->GetDB()->GetPropertiesOfAllTables(cf, &props);
+  if (!s.ok()) {
+    LOG(WARNING) << "[compaction checker] Failed to get table properties, " << s.ToString();
+    return;
+  }
+  // The main goal of compaction was reclaimed the disk space and removed
+  // the tombstone. It seems that compaction checker was unnecessary here when
+  // the live files was too few, Hard code to 1 here.
+  if (props.size() <= 1) return;
+
+  size_t maxFilesToCompaction = 1;
+  if (props.size()/720 > maxFilesToCompaction) {
+    maxFilesToCompaction = props.size()/720;
+  }
+  int64_t now, forceCompactSeconds = 2 * 24 * 3600;
+  rocksdb::Env::Default()->GetCurrentTime(&now);
+  std::string best_filename;
+  double best_delete_ratio = 0;
+  int64_t total_keys = 0, deleted_keys = 0;
+  rocksdb::Slice start_key, stop_key, best_start_key, best_stop_key;
+  for (const auto &iter : props) {
+    if (maxFilesToCompaction == 0) return;
+    // don't compact the SST created in 1 hour
+    if ( iter.second->creation_time < now-3600) continue;
+    for (const auto &property_iter : iter.second->user_collected_properties) {
+      if (property_iter.first == "total_keys") {
+        total_keys = std::atoi(property_iter.second.data());
+      }
+      if (property_iter.first == "deleted_keys") {
+        deleted_keys = std::atoi(property_iter.second.data());
+      }
+      if (property_iter.first == "start_key") {
+        start_key = property_iter.second;
+      }
+      if (property_iter.first == "stop_key") {
+        stop_key = property_iter.second;
+      }
+    }
+
+    // pick the file which was created more than 1 week
+    if ((iter.second->creation_time < static_cast<uint64_t>(now-forceCompactSeconds))
+        || (iter.second->file_creation_time < static_cast<uint64_t>(now-forceCompactSeconds))) {
+      if (start_key.empty() || stop_key.empty()) continue;
+      LOG(INFO) << "[compaction checker] Going to compact the key in file(created more than 2 days): " << iter.first;
+      auto s = storage_->Compact(&start_key, &stop_key);
+      LOG(INFO) << "[compaction checker] Compact the key in file(created more than 2 days): " << iter.first
+                << " finished, result: " << s.ToString();
+      maxFilesToCompaction--;
+    }
+    // pick the file which has highest delete ratio
+    double delete_ratio = static_cast<double>(deleted_keys)/static_cast<double>(total_keys);
+    if (total_keys != 0 && !start_key.empty() && !stop_key.empty()
+        && delete_ratio > best_delete_ratio) {
+      best_delete_ratio = delete_ratio;
+      best_filename = iter.first;
+      best_start_key = std::move(start_key);
+      best_stop_key = std::move(stop_key);
+    }
+  }
+  if (best_delete_ratio > 0.1) {
+    LOG(INFO) << "[compaction checker] Going to compact the key in file: " << best_filename
+              << ", delete ratio: " << best_delete_ratio;
+    storage_->Compact(&best_start_key, &best_stop_key);
+  }
+}

--- a/src/compaction_checker.cc
+++ b/src/compaction_checker.cc
@@ -22,7 +22,6 @@ void CompactionChecker::PickCompactionFiles(const std::string &cf_name) {
   rocksdb::TablePropertiesCollection props;
   rocksdb::ColumnFamilyHandle *cf = storage_->GetCFHandle(cf_name);
 
-  LOG(INFO) << "";
   auto s = storage_->GetDB()->GetPropertiesOfAllTables(cf, &props);
   if (!s.ok()) {
     LOG(WARNING) << "[compaction checker] Failed to get table properties, " << s.ToString();

--- a/src/compaction_checker.h
+++ b/src/compaction_checker.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+#include "storage.h"
+
+class CompactionChecker {
+ public:
+  explicit CompactionChecker(Engine::Storage *storage):storage_(storage) {}
+  ~CompactionChecker() {}
+  void PickCompactionFiles(const std::string &cf_name);
+  void CompactPubsubAndSlotFiles();
+ private:
+  Engine::Storage *storage_ = nullptr;
+};

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,16 @@ const size_t GiB = 1024L * MiB;
 
 extern const char *kDefaultNamespace;
 
+struct CompactionCheckerRange {
+ public:
+  int Start;
+  int Stop;
+
+  bool Enabled() {
+    return Start != -1 || Stop != -1;
+  }
+};
+
 struct Config{
  public:
   Config();
@@ -67,6 +77,7 @@ struct Config{
   int master_port = 0;
   Cron compact_cron;
   Cron bgsave_cron;
+  CompactionCheckerRange compaction_checker_range{-1, -1};
   std::map<std::string, std::string> tokens;
 
   // profiling
@@ -119,6 +130,7 @@ struct Config{
   std::string slaveof_;
   std::string compact_cron_;
   std::string bgsave_cron_;
+  std::string compaction_checker_range_;
   std::string profiling_sample_commands_;
   std::map<std::string, ConfigField*> fields_;
 

--- a/src/server.h
+++ b/src/server.h
@@ -72,6 +72,7 @@ class Server {
   std::string GetLastRandomKeyCursor() { return last_random_key_cursor_; }
   void SetLastRandomKeyCursor(const std::string &cursor) { last_random_key_cursor_ = cursor; }
 
+  static int GetUnixTime();
   void GetStatsInfo(std::string *info);
   void GetServerInfo(std::string *info);
   void GetMemoryInfo(std::string *info);
@@ -109,10 +110,12 @@ class Server {
   Stats stats_;
   Engine::Storage *storage_;
   Redis::SlotsMgrtSenderThread *slotsmgrt_sender_thread_ = nullptr;
+  static std::atomic<int> unix_time_;
 
  private:
   void cron();
   void delConnContext(ConnContext *c);
+  void updateCachedTime();
 
   bool stop_ = false;
   bool is_loading_ = false;
@@ -151,6 +154,7 @@ class Server {
 
   // threads
   std::thread cron_thread_;
+  std::thread compaction_checker_thread_;
   TaskRunner task_runner_;
   std::vector<WorkerThread *> worker_threads_;
   std::unique_ptr<ReplicationThread> replication_thread_;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -178,7 +178,7 @@ Status Storage::Open(bool read_only) {
   subkey_opts.table_factory.reset(rocksdb::NewBlockBasedTableFactory(subkey_table_opts));
   subkey_opts.compaction_filter_factory = std::make_shared<SubKeyFilterFactory>(this);
   subkey_opts.disable_auto_compactions = config_->RocksDB.disable_auto_compactions;
-  metadata_opts.table_properties_collector_factories.emplace_back(
+  subkey_opts.table_properties_collector_factories.emplace_back(
       NewCompactOnExpiredTableCollectorFactory(kSubkeyColumnFamilyName, 0.3));
 
   rocksdb::BlockBasedTableOptions pubsub_table_opts;

--- a/src/storage.h
+++ b/src/storage.h
@@ -23,6 +23,12 @@ enum ColumnFamilyID{
 };
 
 namespace Engine {
+extern const char *kPubSubColumnFamilyName;
+extern const char *kZSetScoreColumnFamilyName;
+extern const char *kMetadataColumnFamilyName;
+extern const char *kSubkeyColumnFamilyName;
+extern const char *kSlotMetadataColumnFamilyName;
+extern const char *kSlotColumnFamilyName;
 
 class Storage {
  public:
@@ -36,7 +42,7 @@ class Storage {
   void InitOptions(rocksdb::Options *options);
   Status SetColumnFamilyOption(const std::string &key, const std::string &value);
   Status SetDBOption(const std::string &key, const std::string &value);
-  Status CreateColumnFamiles(const rocksdb::Options &options);
+  Status CreateColumnFamilies(const rocksdb::Options &options);
   Status CreateBackup();
   Status DestroyBackup();
   Status RestoreFromBackup();
@@ -70,6 +76,7 @@ class Storage {
   void IncrFlushCount(uint64_t n) { flush_count_.fetch_add(n); }
   uint64_t GetCompactionCount() { return compaction_count_; }
   void IncrCompactionCount(uint64_t n) { compaction_count_.fetch_add(n); }
+  bool CodisEnabled() { return config_->codis_enabled; }
 
   Storage(const Storage &) = delete;
   Storage &operator=(const Storage &) = delete;

--- a/src/table_properties_collector.cc
+++ b/src/table_properties_collector.cc
@@ -1,0 +1,82 @@
+#include "table_properties_collector.h"
+#include <utility>
+#include "encoding.h"
+#include "redis_metadata.h"
+#include "server.h"
+
+rocksdb::Status
+CompactOnExpiredCollector::AddUserKey(const rocksdb::Slice &key, const rocksdb::Slice &value,
+    rocksdb::EntryType entry_type, rocksdb::SequenceNumber, uint64_t) {
+  int now;
+  uint8_t type;
+  uint32_t expired, subkeys = 0;
+  uint64_t version;
+
+  if (start_key_.empty()) {
+    start_key_ = key.ToString();
+  }
+  stop_key_ = key.ToString();
+  total_keys_ += 1;
+  if (entry_type == rocksdb::kEntryDelete) {
+    deleted_keys_ += 1;
+    return rocksdb::Status::OK();
+  }
+
+  if (cf_name_ != "metadata") {
+    return rocksdb::Status::OK();
+  }
+  rocksdb::Slice cv = value;
+  if (entry_type != rocksdb::kEntryPut || cv.size() < 5) {
+    return rocksdb::Status::OK();
+  }
+  GetFixed8(&cv, &type);
+  GetFixed32(&cv, &expired);
+  type = type & (uint8_t)0x0f;
+  if (type == kRedisBitmap || type == kRedisSet || type == kRedisList ||
+      type == kRedisHash || type == kRedisZSet || type == kRedisSortedint) {
+      if (cv.size() <= 12) return rocksdb::Status::OK();
+      GetFixed64(&cv, &version);
+      GetFixed32(&cv, &subkeys);
+  }
+  total_keys_ += subkeys;
+  now = Server::GetUnixTime();
+  if ((expired > 0 && expired < static_cast<uint32_t>(now))
+      || (type != kRedisString && subkeys == 0)) {
+    deleted_keys_ += subkeys + 1;
+  }
+  return rocksdb::Status::OK();
+}
+
+rocksdb::Status
+CompactOnExpiredCollector::Finish(rocksdb::UserCollectedProperties *properties) {
+  properties->insert(std::pair<std::string, std::string>{"total_keys", std::to_string(total_keys_)});
+  properties->insert(std::pair<std::string, std::string>{"deleted_keys", std::to_string(deleted_keys_)});
+  properties->insert(std::pair<std::string, std::string>{"start_key", start_key_});
+  properties->insert(std::pair<std::string, std::string>{"stop_key", stop_key_});
+  return rocksdb::Status::OK();
+}
+
+rocksdb::UserCollectedProperties
+CompactOnExpiredCollector::GetReadableProperties() const {
+  rocksdb::UserCollectedProperties properties;
+  properties.insert(std::pair<std::string, std::string>{"total_keys", std::to_string(total_keys_)});
+  properties.insert(std::pair<std::string, std::string>{"deleted_keys", std::to_string(deleted_keys_)});
+  return properties;
+}
+
+bool CompactOnExpiredCollector::NeedCompact() const {
+  if (total_keys_ == 0) return false;
+  return static_cast<float>(deleted_keys_)/ static_cast<float>(total_keys_) > trigger_threshold_;
+}
+
+rocksdb::TablePropertiesCollector *
+CompactOnExpiredTableCollectorFactory::CreateTablePropertiesCollector(
+    rocksdb::TablePropertiesCollectorFactory::Context context) {
+  return new CompactOnExpiredCollector(cf_name_, trigger_threshold_);
+}
+std::shared_ptr<CompactOnExpiredTableCollectorFactory>
+NewCompactOnExpiredTableCollectorFactory(const std::string &cf_name,
+                                         float trigger_threshold) {
+  return std::shared_ptr<CompactOnExpiredTableCollectorFactory>(
+      new CompactOnExpiredTableCollectorFactory(cf_name, trigger_threshold));
+}

--- a/src/table_properties_collector.h
+++ b/src/table_properties_collector.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <utility>
+#include <string>
+#include <memory>
+#include <rocksdb/table_properties.h>
+
+class CompactOnExpiredCollector : public rocksdb::TablePropertiesCollector {
+ public:
+  explicit CompactOnExpiredCollector(const std::string &cf_name, float trigger_threshold)
+      : cf_name_(cf_name), trigger_threshold_(trigger_threshold) {}
+  const char * Name() const override { return "compact_on_expired_collector"; }
+  bool NeedCompact() const override;
+  rocksdb::Status AddUserKey(const rocksdb::Slice &key, const rocksdb::Slice &value,
+      rocksdb::EntryType, rocksdb::SequenceNumber, uint64_t) override;
+  rocksdb::Status Finish(rocksdb::UserCollectedProperties *properties) override;
+  rocksdb::UserCollectedProperties GetReadableProperties() const override;
+
+ private:
+  std::string cf_name_;
+  float trigger_threshold_;
+  int64_t total_keys_ = 0;
+  int64_t deleted_keys_ = 0;
+  std::string start_key_;
+  std::string stop_key_;
+};
+
+class CompactOnExpiredTableCollectorFactory: public rocksdb::TablePropertiesCollectorFactory {
+ public:
+  explicit CompactOnExpiredTableCollectorFactory(const std::string &cf_name,
+                                                 float trigger_threshold) :
+                                                 cf_name_(std::move(cf_name)),
+                                                 trigger_threshold_(trigger_threshold) {}
+  virtual ~CompactOnExpiredTableCollectorFactory() {}
+  rocksdb::TablePropertiesCollector* CreateTablePropertiesCollector(
+      rocksdb::TablePropertiesCollectorFactory::Context context) override;
+  const char * Name() const override {
+    return "CompactOnExpiredCollector";
+  }
+
+ private:
+  friend std::shared_ptr<CompactOnExpiredTableCollectorFactory>
+    NewCompactOnExpiredTableCollectorFactory(const std::string &cf_name,
+                                             float trigger_threshold);
+  std::string cf_name_;
+  float trigger_threshold_ = 0.3;
+};
+
+extern std::shared_ptr<CompactOnExpiredTableCollectorFactory>
+NewCompactOnExpiredTableCollectorFactory(const std::string &cf_name,
+                                         float trigger_threshold);

--- a/src/task_runner.h
+++ b/src/task_runner.h
@@ -17,7 +17,7 @@ struct Task {
 
 class TaskRunner {
  public:
-  explicit TaskRunner(int n_thread = 2, uint32_t max_queue_size = 10240)
+  explicit TaskRunner(int n_thread = 1, uint32_t max_queue_size = 10240)
   :max_queue_size_(max_queue_size), n_thread_(n_thread) {}
   ~TaskRunner() = default;
   Status Publish(Task task);


### PR DESCRIPTION
the main goal of the compaction checker was to avoid unnecessary full compaction every day. How it works:
* step 1: check the current hour whether in compaction checker range or not, if yes go to step 2
* step 2: fetch all table properties and then pick the file was created
more than 1 week or which has highest delete ratio every minute
* step 3: compact keys in the selected file


### TODO

- [x]  fix pubsub/slot compaction

- [x]  test compaction checker was worked as expected

- [ ] smarter compaction rule