### PR TITLE
FIX: impove the multi-bulk string function performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,7 @@ add_executable(unittest
         tests/t_zset_test.cc
         tests/t_geo_test.cc
         tests/t_metadata_test.cc
+        tests/string_reply_test.cc
         tests/string_util_test.cc
         tests/rwlock_test.cc
         tests/cron_test.cc

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,7 @@ KVROCKS_OBJS= $(SHARED_OBJS) main.o
 
 UNITTEST_OBJS= $(SHARED_OBJS) ../tests/main.o ../tests/t_metadata_test.o ../tests/compact_test.o \
 			   ../tests/config_test.o ../tests/cron_test.o ../tests/log_collector_test.o \
-			   ../tests/rwlock_test.o ../tests/string_util_test.o ../tests/t_bitmap_test.o \
+			   ../tests/rwlock_test.o ../tests/string_reply_test.o ../tests/string_util_test.o ../tests/t_bitmap_test.o \
 			   ../tests/t_encoding_test.o ../tests/t_hash_test.o ../tests/t_list_test.o ../tests/t_set_test.o \
 			   ../tests/task_runner_test.o  ../tests/t_string_test.o ../tests/t_zset_test.o ../tests/t_geo_test.o \
 			    ../tests/t_sortedint_test.o

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -1233,11 +1233,11 @@ class CommandHVals : public Commander {
     if (!s.ok()) {
       return Status(Status::RedisExecErr, s.ToString());
     }
-    std::vector<std::string> values;
+    
+    *output = "*" + std::to_string(field_values.size()) + CRLF;
     for (const auto fv : field_values) {
-      values.emplace_back(fv.value);
+      *output += Redis::BulkString(fv.value);
     }
-    *output = Redis::MultiBulkString(values, false);
     return Status::OK();
   }
 };

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -1233,7 +1233,6 @@ class CommandHVals : public Commander {
     if (!s.ok()) {
       return Status(Status::RedisExecErr, s.ToString());
     }
-    
     *output = "*" + std::to_string(field_values.size()) + CRLF;
     for (const auto fv : field_values) {
       *output += Redis::BulkString(fv.value);

--- a/src/redis_reply.cc
+++ b/src/redis_reply.cc
@@ -48,7 +48,14 @@ std::string MultiBulkString(std::vector<std::string> values, const std::vector<r
   return Array(values);
 }
 std::string Array(std::vector<std::string> list) {
-  return std::accumulate(list.begin(), list.end(), "*" + std::to_string(list.size()) + CRLF);
+  std::string::size_type n = std::accumulate( 
+    list.begin(), list.end(), std::string::size_type( 0 ),
+    [] ( std::string::size_type n, const std::string &s ) { return ( n += s.size() ); });
+  
+  std::string result = "*" + std::to_string(list.size()) + CRLF;
+  result.reserve(n);
+  return std::accumulate(list.begin(), list.end(), result, [](std::string &dest, std::string const &item) -> std::string& {dest += item; return dest;});
+
 }
 
 }  // namespace Redis

--- a/src/redis_reply.cc
+++ b/src/redis_reply.cc
@@ -48,14 +48,13 @@ std::string MultiBulkString(std::vector<std::string> values, const std::vector<r
   return Array(values);
 }
 std::string Array(std::vector<std::string> list) {
-  std::string::size_type n = std::accumulate( 
-    list.begin(), list.end(), std::string::size_type( 0 ),
+  std::string::size_type n = std::accumulate(
+    list.begin(), list.end(), std::string::size_type(0),
     [] ( std::string::size_type n, const std::string &s ) { return ( n += s.size() ); });
-  
   std::string result = "*" + std::to_string(list.size()) + CRLF;
   result.reserve(n);
-  return std::accumulate(list.begin(), list.end(), result, [](std::string &dest, std::string const &item) -> std::string& {dest += item; return dest;});
-
+  return std::accumulate(list.begin(), list.end(), result,
+    [](std::string &dest, std::string const &item) -> std::string& {dest += item; return dest;});
 }
 
 }  // namespace Redis

--- a/tests/string_reply_test.cc
+++ b/tests/string_reply_test.cc
@@ -1,0 +1,39 @@
+#include <gtest/gtest.h>
+
+#include "redis_reply.h"
+
+
+class StringReplyTest : public testing::Test {
+    protected:
+    static void SetUpTestCase() {
+        for(int i =0; i< 100000; i++) {
+            values.emplace_back("values" + std::to_string(i));
+        }
+    }
+    static void TearDownTestCase() {
+        values.clear();
+    }
+    static std::vector<std::string> values;
+    virtual void SetUp() {}
+
+    virtual void TearDown() {}
+};
+
+std::vector<std::string> StringReplyTest::values;
+
+TEST_F(StringReplyTest, MultiBulkString) {
+
+    std::string result = Redis::MultiBulkString(values);
+    ASSERT_EQ(result.length(), 13*10+14*90+15*900+17*9000+18*90000+9);
+}
+
+TEST_F(StringReplyTest, BulkString) {
+
+    std::string result = "*" + std::to_string(values.size()) + CRLF;
+    for (const auto &v : values) {
+      result += Redis::BulkString(v);
+    }
+
+    ASSERT_EQ(result.length(), 13*10+14*90+15*900+17*9000+18*90000+9);
+
+}

--- a/tests/string_reply_test.cc
+++ b/tests/string_reply_test.cc
@@ -1,12 +1,10 @@
 #include <gtest/gtest.h>
-
 #include "redis_reply.h"
 
-
 class StringReplyTest : public testing::Test {
-    protected:
+ protected:
     static void SetUpTestCase() {
-        for(int i =0; i< 100000; i++) {
+        for (int i = 0; i < 100000; i++) {
             values.emplace_back("values" + std::to_string(i));
         }
     }
@@ -22,18 +20,15 @@ class StringReplyTest : public testing::Test {
 std::vector<std::string> StringReplyTest::values;
 
 TEST_F(StringReplyTest, MultiBulkString) {
-
     std::string result = Redis::MultiBulkString(values);
     ASSERT_EQ(result.length(), 13*10+14*90+15*900+17*9000+18*90000+9);
 }
 
 TEST_F(StringReplyTest, BulkString) {
-
     std::string result = "*" + std::to_string(values.size()) + CRLF;
     for (const auto &v : values) {
       result += Redis::BulkString(v);
     }
 
     ASSERT_EQ(result.length(), 13*10+14*90+15*900+17*9000+18*90000+9);
-
 }


### PR DESCRIPTION
FIX: impove the multi-bulk string function performance

Array function is low efficiency if vector owns a large number of data. It will slow down some command executions like 'hvals'. 
Modified the function to avoid to create memory space frequently. 
In hvals command, no need to package rocksdb return as a vector (like hgetall), it losts performance, use plus op directly can be provide more 30% perf up than multibulk function (under 100 thousand items)