### PR TITLE
Fix hash tag calculation error

### DIFF
--- a/src/redis_slot.cc
+++ b/src/redis_slot.cc
@@ -57,8 +57,11 @@ uint32_t GetSlotNumFromKey(const std::string &key) {
 std::string GetTagFromKey(const std::string &key) {
   auto left_pos = key.find("{");
   if (left_pos == std::string::npos) return std::string();
-  auto right_pos = key.find("}");
-  if (right_pos == std::string::npos || right_pos < left_pos) return std::string();
+  auto right_pos = key.find("}", left_pos + 1);
+  // Note that we hash the whole key if there is nothing between {}.
+  if (right_pos == std::string::npos || right_pos <= left_pos + 1) {
+    return std::string();
+  }
 
   return key.substr(left_pos + 1, right_pos - left_pos - 1);
 }


### PR DESCRIPTION
Redis: 
https://github.com/redis/redis/blob/unstable/src/cluster.c#L747
tewmproxy: https://github.com/twitter/twemproxy/blob/c5c725d2b45715e378909ebc909b0492591c4715/src/nc_server.c#L665
Codis:
https://github.com/CodisLabs/codis/blob/7191a280026cefd50a09db6ba82fe180249d78b0/pkg/proxy/mapper.go#L303

We should find '}'  from after '{'. 
I know little about go language, but I think Codis has different hag tag calculation with others when the key has "{}" with nothing between "{}". right ?

BTW, I think we should use 'Slice'(just leveldb and rocksdb) to avoid unnecessary copy