### PR TITLE
Support to set separate log directory

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -69,6 +69,11 @@ db-name change.me.db
 # Note that you must specify a directory here, not a file name.
 dir /tmp/kvrocks
 
+# The logs of server will be stored in this directory. If you don't specify
+# one directory, by default, we store logs in the working directory that set
+# by 'dir' above.
+# log-dir /tmp/kvrocks
+
 # When running daemonized, kvrocks writes a pid file in ${CONFIG_DIR}/kvrocks.pid by
 # default. You can specify a custom pid file location here.
 # pidfile /var/run/kvrocks.pid

--- a/src/config.cc
+++ b/src/config.cc
@@ -82,6 +82,7 @@ Config::Config() {
       {"db-name", true, new StringField(&db_name, "changeme.name")},
       {"dir", true, new StringField(&dir, "/tmp/kvrocks")},
       {"backup-dir", true, new StringField(&backup_dir, "")},
+      {"log-dir", true, new StringField(&log_dir, "")},
       {"pidfile", true, new StringField(&pidfile, "")},
       {"max-io-mb", false, new IntField(&max_io_mb, 500, 0, INT_MAX)},
       {"max-db-size", false, new IntField(&max_db_size, 0, 0, INT_MAX)},
@@ -191,6 +192,7 @@ void Config::initFieldCallback() {
       {"dir", [this](Server* srv,  const std::string &k, const std::string& v)->Status {
         db_dir = dir + "/db";
         if (backup_dir.empty()) backup_dir = dir + "/backup";
+        if (log_dir.empty()) log_dir = dir;
         return Status::OK();
       }},
       {"port", [this](Server* srv,  const std::string &k, const std::string& v)->Status {
@@ -364,6 +366,7 @@ Status Config::finish() {
   }
   if (db_dir.empty()) db_dir = dir + "/db";
   if (backup_dir.empty()) backup_dir = dir + "/backup";
+  if (log_dir.empty()) log_dir = dir;
   if (pidfile.empty()) pidfile = dir + "/kvrocks.pid";
   std::vector<std::string> createDirs = {dir, backup_dir};
   for (const auto &name : createDirs) {

--- a/src/config.h
+++ b/src/config.h
@@ -69,6 +69,7 @@ struct Config{
   std::string dir;
   std::string db_dir;
   std::string backup_dir;
+  std::string log_dir;
   std::string pidfile;
   std::string db_name;
   std::string masterauth;

--- a/src/main.cc
+++ b/src/main.cc
@@ -146,7 +146,7 @@ static void initGoogleLog(const Config *config) {
   FLAGS_minloglevel = config->loglevel;
   FLAGS_max_log_size = 100;
   FLAGS_logbufsecs = 0;
-  FLAGS_log_dir = config->dir;
+  FLAGS_log_dir = config->log_dir;
 }
 
 bool supervisedUpstart() {


### PR DESCRIPTION
If logs of server are stored in working directory, there may be a little messy, I think we  support to set separate log directory, so i add a configuration to support that.