### PR TITLE
Implement psetex command and handle negative expire time when set

### DIFF
--- a/tests/functional/string_test.py
+++ b/tests/functional/string_test.py
@@ -101,13 +101,13 @@ def test_setex():
 def test_psetex():
     key = "test_psetex"
     conn = get_redis_conn()
-    ret = conn.psetex(key, "bar", 1000*1024)
+    ret = conn.psetex(key, 1000*1024, "bar")
     assert(ret == True)
     ret = conn.ttl(key)
     assert(ret >= 1023 and ret <= 1025)
     ret = conn.delete(key)
     assert(ret == 1)
-    assert_raise(redis.RedisError, conn.psetex, "foo", "bar", "invalid")
+    assert_raise(redis.RedisError, conn.psetex, "foo", "invalid", "bar")
 
 def test_setnx():
     key = "test_setnx"

--- a/tests/functional/string_test.py
+++ b/tests/functional/string_test.py
@@ -98,6 +98,17 @@ def test_setex():
     assert(ret == 1)
     assert_raise(redis.RedisError, conn.setex, "foo", "bar", "invalid")
 
+def test_psetex():
+    key = "test_psetex"
+    conn = get_redis_conn()
+    ret = conn.psetex(key, "bar", 1000*1024)
+    assert(ret == True)
+    ret = conn.ttl(key)
+    assert(ret >= 1023 and ret <= 1025)
+    ret = conn.delete(key)
+    assert(ret == 1)
+    assert_raise(redis.RedisError, conn.psetex, "foo", "bar", "invalid")
+
 def test_setnx():
     key = "test_setnx"
     conn = get_redis_conn()


### PR DESCRIPTION
We said we support `psetex` command but actually we don't support, and no body finds that 🤣

For `setex` `psetex`  `set ex/pex` commands, we should check expire time is negative or not. 
There is redis code https://github.com/redis/redis/blob/unstable/src/t_string.c#L81