### PR TITLE
Fix some list bug

### DIFF
--- a/src/redis_list.cc
+++ b/src/redis_list.cc
@@ -393,11 +393,13 @@ rocksdb::Status List::Set(const Slice &user_key, int index, Slice elem) {
 
 rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string *elem) {
   RedisType type;
-  if (!(Type(dst, &type).ok() && (type == kRedisNone || type == kRedisList))) {
+  rocksdb::Status s = Type(dst, &type);
+  if (!s.ok()) return s;
+  if (type != kRedisNone && type != kRedisList) {
     return rocksdb::Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
   }
 
-  rocksdb::Status s = Pop(src, elem, false);
+  s = Pop(src, elem, false);
   if (!s.ok()) return s;
 
   int ret;

--- a/src/redis_list.cc
+++ b/src/redis_list.cc
@@ -244,6 +244,7 @@ rocksdb::Status List::Insert(const Slice &user_key, const Slice &pivot, const Sl
   }
   if (pivot_index == (metadata.head - 1)) {
     delete iter;
+    *ret = -1;
     return rocksdb::Status::NotFound();
   }
 
@@ -391,6 +392,11 @@ rocksdb::Status List::Set(const Slice &user_key, int index, Slice elem) {
 }
 
 rocksdb::Status List::RPopLPush(const Slice &src, const Slice &dst, std::string *elem) {
+  RedisType type;
+  if (!(Type(dst, &type).ok() && (type == kRedisNone || type == kRedisList))) {
+    return rocksdb::Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
+  }
+
   rocksdb::Status s = Pop(src, elem, false);
   if (!s.ok()) return s;
 
@@ -413,7 +419,7 @@ rocksdb::Status List::Trim(const Slice &user_key, int start, int stop) {
   if (!s.ok()) return s.IsNotFound() ? rocksdb::Status::OK() : s;
 
   if (start < 0) start = metadata.size + start;
-  if (stop < 0) stop = static_cast<int>(metadata.size) > -1 * stop ? metadata.size + stop : metadata.size;
+  if (stop < 0) stop = static_cast<int>(metadata.size) >= -1 * stop ? metadata.size + stop : -1;
   // the result will be empty list when start > stop,
   // or start is larger than the end of list
   if (start > stop) {


### PR DESCRIPTION
- For rpoplpush command, don't pop keys if dst key is not list
- For linsert command, return -1 if don't find index
- Fix ltrim command range calculation


For ltrim command, bad cases are following
```
lpush key 1 2 3 4 5
ltrim key 0 -5 => should return 1, instead of  1 2 3 4 5
ltrim key 0 -6 => should return empty, instead of 1 2 3 4 5
```