### PR TITLE
Fix reply content for pattern subscribers when publish message

### DIFF
--- a/tests/functional/pub_sub_test.py
+++ b/tests/functional/pub_sub_test.py
@@ -23,7 +23,7 @@ def psubscribe(pattern, master=True):
     p.psubscribe(pattern)
 
     for item in p.listen():
-        if item['type'] == "message":
+        if item['type'] == "pmessage":
             assert (item['data'] == "a")
             p.punsubscribe()
             break


### PR DESCRIPTION
For pattern subscribers, we should publish` pmessage, pattern, channel and message` for connections when clients publish message.