### PR TITLE
Handle the query starting with \r\n

### DIFF
--- a/src/redis_request.cc
+++ b/src/redis_request.cc
@@ -28,7 +28,10 @@ Status Request::Tokenize(evbuffer *input) {
           if (pipeline_size > 128) {
             LOG(INFO) << "Large pipeline detected: " << pipeline_size;
           }
-          if (line) continue;
+          if (line) {
+            free(line);
+            continue;
+          }
           return Status::OK();
         }
         pipeline_size++;

--- a/src/redis_request.cc
+++ b/src/redis_request.cc
@@ -28,6 +28,7 @@ Status Request::Tokenize(evbuffer *input) {
           if (pipeline_size > 128) {
             LOG(INFO) << "Large pipeline detected: " << pipeline_size;
           }
+          if (line) continue;
           return Status::OK();
         }
         pipeline_size++;


### PR DESCRIPTION
I found tcl test sometimes may be time out
https://github.com/bitleak/kvrocks/runs/1932218223?check_suite_focus=true#step:8:569
because kvrocks may not continue to process clients' request if last query starting with \r\n.

```tcl
test "Handle an empty query" {
    reconnect
    r write "\r\n"
    r flush
    assert_equal "PONG" [r ping]
}
```
Why does this test sometimes timeout? i guess that kvrocks doesn't process the query after `r flush`, or the `ping` query will start with  \r\n