### PR TITLE
Enable the socket option tcp keepalive and no delay by default

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -70,6 +70,20 @@ const std::string Float2String(double d) {
   return buf;
 }
 
+Status SockSetTcpNoDelay(int fd, int val) {
+  if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) == -1) {
+    return Status(Status::NotOK, strerror(errno));
+  }
+  return Status::OK();
+}
+
+Status SockSetTcpKeepalive(int fd, int val) {
+  if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) == -1) {
+    return Status(Status::NotOK, strerror(errno));
+  }
+  return Status::OK();
+}
+
 Status SockConnect(std::string host, uint32_t port, int *fd, uint64_t conn_timeout, uint64_t timeout) {
   if (conn_timeout == 0) {
     auto s = SockConnect(host, port, fd);
@@ -107,8 +121,8 @@ Status SockConnect(std::string host, uint32_t port, int *fd, uint64_t conn_timeo
       *fd = -1;
       return Status(Status::NotOK, strerror(errno));
     }
-    setsockopt(*fd, SOL_SOCKET, SO_KEEPALIVE, nullptr, 0);
-    setsockopt(*fd, IPPROTO_TCP, TCP_NODELAY, nullptr, 0);
+    SockSetTcpNoDelay(*fd, 1);
+    SockSetTcpNoDelay(*fd, 1);
   }
   if (timeout > 0) {
     struct timeval tv;

--- a/src/util.h
+++ b/src/util.h
@@ -40,6 +40,8 @@ namespace Util {
 sockaddr_in NewSockaddrInet(const std::string &host, uint32_t port);
 Status SockConnect(std::string host, uint32_t port, int *fd);
 Status SockConnect(std::string host, uint32_t port, int *fd, uint64_t conn_timeout, uint64_t timeout = 0);
+Status SockSetTcpNoDelay(int fd, int val);
+Status SockSetTcpKeepalive(int fd, int val);
 Status SockSend(int fd, const std::string &data);
 Status SockReadLine(int fd, std::string *data);
 int GetPeerAddr(int fd, std::string *addr, uint32_t *port);


### PR DESCRIPTION
TCP keepalive was used to detect whether a TCP connection died or not. TCP no-delay option was used to disable the Nagle algorithm which occurs delay ACK(default in Linux was 40ms) may cause high latency. 