### PR TITLE
Support to set max total wal size for rocksdb

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -320,6 +320,27 @@ rocksdb.max_sub_compactions 2
 # Defalut: 1 Hours
 rocksdb.wal_ttl_seconds 3600
 
+# In order to limit the size of WALs, RocksDB uses DBOptions::max_total_wal_size
+# as the trigger of column family flush. Once WALs exceed this size, RocksDB
+# will start forcing the flush of column families to allow deletion of some
+# oldest WALs. This config can be useful when column families are updated at
+# non-uniform frequencies. If there's no size limit, users may need to keep
+# really old WALs when the infrequently-updated column families hasn't flushed
+# for a while.
+#
+# In kvrocks, we use multiple column families to store metadata, subkeys, etc.
+# If users always use string type, but use list, hash and other complex data types
+# infrequently, there will be a lot of old WALs if we don't set size limit
+# (0 by default in rocksdb), because rocksdb will dynamically choose the WAL size
+# limit to be [sum of all write_buffer_size * max_write_buffer_number] * 4 if set to 0.
+#
+# Moreover, you should increase this value if you already set rocksdb.write_buffer_size
+# to a big value, to avoid influencing the effect of rocksdb.write_buffer_size and
+# rocksdb.max_write_buffer_number.
+#
+# default is 512MB
+rocksdb.max_total_wal_size 512
+
 # If WAL_ttl_seconds is 0 and WAL_size_limit_MB is not 0,
 # WAL files will be checked every 10 min and if total size is greater
 # then WAL_size_limit_MB, they will be deleted starting with the

--- a/src/config.cc
+++ b/src/config.cc
@@ -111,6 +111,7 @@ Config::Config() {
       {"rocksdb.delayed_write_rate", false, new Int64Field(&RocksDB.delayed_write_rate, 0, 0, INT64_MAX)},
       {"rocksdb.wal_ttl_seconds", true, new IntField(&RocksDB.WAL_ttl_seconds, 7*24*3600, 0, INT_MAX)},
       {"rocksdb.wal_size_limit_mb", true, new IntField(&RocksDB.WAL_size_limit_MB, 5120, 0, INT_MAX)},
+      {"rocksdb.max_total_wal_size", false, new IntField(&RocksDB.max_total_wal_size, 64*4*2, 0, INT_MAX)},
       {"rocksdb.disable_auto_compactions", false, new YesNoField(&RocksDB.disable_auto_compactions, false)},
       {"rocksdb.enable_pipelined_write", true, new YesNoField(&RocksDB.enable_pipelined_write, false)},
       {"rocksdb.stats_dump_period_sec", false, new IntField(&RocksDB.stats_dump_period_sec, 0, 0, INT_MAX)},
@@ -287,6 +288,11 @@ void Config::initFieldCallback() {
         if (!srv) return Status::OK();
         std::string disable_auto_compactions = v == "yes" ? "true" : "false";
         return srv->storage_->SetColumnFamilyOption(trimRocksDBPrefix(k), disable_auto_compactions);
+      }},
+      {"rocksdb.max_total_wal_size", [this](Server* srv, const std::string &k, const std::string& v)->Status {
+        if (!srv) return Status::OK();
+        return srv->storage_->SetDBOption(trimRocksDBPrefix(k),
+                                          std::to_string(RocksDB.max_total_wal_size * MiB));
       }},
       {"rocksdb.max_open_files", set_db_option_cb},
       {"rocksdb.stats_dump_period_sec", set_db_option_cb},

--- a/src/config.h
+++ b/src/config.h
@@ -106,6 +106,7 @@ struct Config{
     int target_file_size_base;
     int WAL_ttl_seconds;
     int WAL_size_limit_MB;
+    int max_total_wal_size;
     int level0_slowdown_writes_trigger;
     int level0_stop_writes_trigger;
     int compression;

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -90,6 +90,7 @@ void Storage::InitOptions(rocksdb::Options *options) {
   options->keep_log_file_num = 12;
   options->WAL_ttl_seconds = static_cast<uint64_t>(config_->RocksDB.WAL_ttl_seconds);
   options->WAL_size_limit_MB = static_cast<uint64_t>(config_->RocksDB.WAL_size_limit_MB);
+  options->max_total_wal_size = static_cast<uint64_t>(config_->RocksDB.max_total_wal_size * MiB);
   options->listeners.emplace_back(new EventListener(this));
   options->dump_malloc_stats = true;
   sst_file_manager_ = std::shared_ptr<rocksdb::SstFileManager>(rocksdb::NewSstFileManager(rocksdb::Env::Default()));


### PR DESCRIPTION
In kvrocks, we use multiple column families to store metadata, subkeys, etc.
If users always use string type, but use list, hash and other complex data types
infrequently, there will be a lot of old WALs if we don't set size limit
(0 by default in rocksdb), because rocksdb will dynamically choose the WAL size
limit to be [sum of all write_buffer_size * max_write_buffer_number] * 4 if set to 0.

For max_total_wal_size usage
> // Once write-ahead logs exceed this size, we will start forcing the flush of
>   // column families whose memtables are backed by the oldest live WAL file
>   // (i.e. the ones that are causing all the space amplification). If set to 0
>   // (default), we will dynamically choose the WAL size limit to be
>   // [sum of all write_buffer_size * max_write_buffer_number] * 4
>   // This option takes effect only when there are more than one column family as
>   // otherwise the wal size is dictated by the write_buffer_size.
>   //
>   // Default: 0
>   //
>   // Dynamically changeable through SetDBOptions() API.

Related
https://github.com/facebook/rocksdb/issues/5789
https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log#dboptionsmax_total_wal_size
