### PR TITLE
Don't use extra port for replication

### DIFF
--- a/kvrocks.conf
+++ b/kvrocks.conf
@@ -110,9 +110,16 @@ slave-priority 100
 # in order to Get the desired effect.
 tcp-backlog 511
 
-# repl-bind 192.168.1.100 10.0.0.1
-# repl-bind 127.0.0.1
-repl-bind 0.0.0.0
+# If the master is an old version, it may have specified replication threads
+# that use 'port + 1' as listening port, but in new versions, we don't use
+# extra port to implement replication. In order to allow the new replicas to
+# copy old masters, you should indicate that the master uses replication port
+# or not.
+# If yes, that indicates master uses replication port and replicas will connect
+# to 'master's listening port + 1' when synchronization.
+# If no, that indicates master doesn't use replication port and replicas will
+# connect 'master's listening port' when synchronization.
+master-use-repl-port no
 
 # Master-Slave replication. Use slaveof to make a kvrocks instance a copy of
 # another kvrocks server. A few things to understand ASAP about kvrocks replication.

--- a/src/config.h
+++ b/src/config.h
@@ -44,7 +44,6 @@ struct Config{
   Config();
   ~Config();
   int port = 6666;
-  int repl_port = 66667;
   int workers = 0;
   int repl_workers = 1;
   int timeout = 0;
@@ -64,8 +63,8 @@ struct Config{
   int max_replication_mb = 0;
   int max_io_mb = 0;
   bool codis_enabled = false;
+  bool master_use_repl_port = false;
   std::vector<std::string> binds;
-  std::vector<std::string> repl_binds;
   std::string dir;
   std::string db_dir;
   std::string backup_dir;
@@ -128,7 +127,6 @@ struct Config{
  private:
   std::string path_;
   std::string binds_;
-  std::string repl_binds_;
   std::string slaveof_;
   std::string compact_cron_;
   std::string bgsave_cron_;

--- a/src/main.cc
+++ b/src/main.cc
@@ -290,11 +290,6 @@ int main(int argc, char* argv[]) {
               << config.port << "] is already in use" << std::endl;
     exit(1);
   }
-  if (Util::IsPortInUse(config.repl_port)) {
-    std::cout << "Failed to start the server, the specified replication port["
-              << config.repl_port << "] is already in use" << std::endl;
-    exit(1);
-  }
   bool is_supervised = isSupervisedMode(config.supervised_mode);
   if (config.daemonize && !is_supervised) daemonize();
   s = createPidFile(config.pidfile);

--- a/src/redis_cmd.cc
+++ b/src/redis_cmd.cc
@@ -4058,22 +4058,45 @@ class CommandFetchMeta : public Commander {
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    uint64_t file_size;
-    rocksdb::BackupID meta_id;
-    int fd;
-    auto s = Engine::Storage::BackupManager::OpenLatestMeta(
-        svr->storage_, &fd, &meta_id, &file_size);
-    if (!s.IsOK()) {
-      LOG(ERROR) << "Failed to open latest meta, err: " << s.Msg();
-      return Status(Status::DBBackupFileErr, "can't create db backup");
-    }
-    // Send the meta ID
-    conn->Reply(std::to_string(meta_id) + CRLF);
-    // Send meta file size
-    conn->Reply(std::to_string(file_size) + CRLF);
-    // Send meta content
-    conn->SendFile(fd);
+    int repl_fd = conn->GetFD();
+    std::string ip = conn->GetIP();
+
+    Util::SockSetBlocking(repl_fd, 1);
+    conn->NeedNotClose();
+    conn->EnableFlag(Redis::Connection::kCloseAsync);
     svr->stats_.IncrFullSyncCounter();
+
+    // Feed-replica-meta thread
+    std::thread t = std::thread([svr, repl_fd, ip]() {
+      Util::ThreadSetName("feed-replica-meta");
+      int fd;
+      uint64_t file_size;
+      rocksdb::BackupID meta_id;
+      auto s = Engine::Storage::BackupManager::OpenLatestMeta(
+          svr->storage_, &fd, &meta_id, &file_size);
+      if (!s.IsOK()) {
+        const char *message = "-ERR can't create db backup";
+        write(repl_fd, message, strlen(message));
+        LOG(ERROR) << "[replication] Failed to open latest meta, err: "
+                   << s.Msg();
+        close(repl_fd);
+        return;
+      }
+      // Send the meta ID, meta file size and content
+      if (Util::SockSend(repl_fd, std::to_string(meta_id)+CRLF).IsOK() &&
+          Util::SockSend(repl_fd, std::to_string(file_size)+CRLF).IsOK() &&
+          Util::SockSendFile(repl_fd, fd, file_size).IsOK()) {
+        LOG(INFO) << "[replication] Succeed sending backup meta " << meta_id
+                  << " to " << ip;
+      } else {
+        LOG(WARNING) << "[replication] Fail to send backup meta" << meta_id
+                     << ip << ", error: " << strerror(errno);
+      }
+      close(fd);
+      close(repl_fd);
+    });
+    t.detach();
+
     return Status::OK();
   }
 };
@@ -4083,22 +4106,70 @@ class CommandFetchFile : public Commander {
   CommandFetchFile() : Commander("_fetch_file", 2, false) {}
 
   Status Parse(const std::vector<std::string> &args) override {
-    path_ = args[1];
+    paths_sts_ = args[1];
     return Status::OK();
   }
 
   Status Execute(Server *svr, Connection *conn, std::string *output) override {
-    uint64_t file_size = 0;
-    auto fd = Engine::Storage::BackupManager::OpenDataFile(svr->storage_, path_,
-                                                           &file_size);
-    if (fd < 0) return Status(Status::DBBackupFileErr);
-    conn->Reply(std::to_string(file_size) + CRLF);
-    conn->SendFile(fd);
+    std::vector<std::string> paths;
+    Util::Split(paths_sts_, ",", &paths);
+
+    int repl_fd = conn->GetFD();
+    std::string ip = conn->GetIP();
+
+    Util::SockSetBlocking(repl_fd, 1);
+    conn->NeedNotClose();  // Feed-replica-file thread will close the replica fd
+    conn->EnableFlag(Redis::Connection::kCloseAsync);
+
+    std::thread t = std::thread([svr, repl_fd, ip, paths]() {
+      Util::ThreadSetName("feed-replica-file");
+      svr->IncrFetchFileThread();
+
+      for (auto path : paths) {
+        uint64_t file_size = 0, max_replication_bytes = 0;
+        if (svr->GetConfig()->max_replication_mb > 0) {
+          max_replication_bytes = (svr->GetConfig()->max_replication_mb*MiB) /
+                                   svr->GetFetchFileThreadNum();
+        }
+        auto start = std::chrono::high_resolution_clock::now();
+        auto fd = Engine::Storage::BackupManager::OpenDataFile(svr->storage_,
+                                                      path, &file_size);
+        if (fd < 0) break;
+
+        // Send file size and content
+        if (Util::SockSend(repl_fd, std::to_string(file_size)+CRLF).IsOK() &&
+            Util::SockSendFile(repl_fd, fd, file_size).IsOK()) {
+          LOG(INFO) << "[replication] Succeed sending file " << path << " to "
+                    << ip;
+        } else {
+          LOG(WARNING) << "[replication] Fail to send file " << path << " to "
+                       << ip << ", error: " << strerror(errno);
+        }
+        close(fd);
+
+        // Sleep if the speed of sending file is more than replication speed limit
+        auto end = std::chrono::high_resolution_clock::now();
+        uint64_t duration = std::chrono::duration_cast<std::chrono::microseconds>
+                  (end - start).count();
+        uint64_t shortest = static_cast<uint64_t>(static_cast<double>(file_size) /
+                                max_replication_bytes * (1000 * 1000));
+        if (max_replication_bytes > 0 && duration < shortest) {
+          LOG(INFO) << "[replication] Need to sleep "
+                     << (shortest - duration) / 1000
+                     << " ms since of sending files too quickly";
+          usleep(shortest - duration);
+        }
+      }
+      svr->DecrFetchFileThread();
+      close(repl_fd);
+    });
+    t.detach();
+
     return Status::OK();
   }
 
  private:
-  std::string path_;
+  std::string paths_sts_;
 };
 
 class CommandDBName : public Commander {
@@ -4697,12 +4768,8 @@ std::map<std::string, CommanderFactory> command_table = {
     ADD_CMD("flushbackup",  CommandFlushBackup),
     ADD_CMD("slaveof", CommandSlaveOf),
     ADD_CMD("stats",   CommandStats),
-};
 
-// Replication related commands, which are received by workers listening on
-// `repl-port`
-std::map<std::string, CommanderFactory> repl_command_table = {
-    ADD_CMD("auth",        CommandAuth),
+    // Replicaion commands
     ADD_CMD("replconf",    CommandReplConf),
     ADD_CMD("psync",       CommandPSync),
     ADD_CMD("_fetch_meta", CommandFetchMeta),
@@ -4713,19 +4780,11 @@ std::map<std::string, CommanderFactory> repl_command_table = {
 Status LookupCommand(const std::string &cmd_name,
                      std::unique_ptr<Commander> *cmd, bool is_repl) {
   if (cmd_name.empty()) return Status(Status::RedisUnknownCmd);
-  if (is_repl) {
-    auto cmd_factory = repl_command_table.find(Util::ToLower(cmd_name));
-    if (cmd_factory == repl_command_table.end()) {
-      return Status(Status::RedisUnknownCmd);
-    }
-    *cmd = cmd_factory->second();
-  } else {
-    auto cmd_factory = command_table.find(Util::ToLower(cmd_name));
-    if (cmd_factory == command_table.end()) {
-      return Status(Status::RedisUnknownCmd);
-    }
-    *cmd = cmd_factory->second();
+  auto cmd_factory = command_table.find(Util::ToLower(cmd_name));
+  if (cmd_factory == command_table.end()) {
+    return Status(Status::RedisUnknownCmd);
   }
+  *cmd = cmd_factory->second();
   return Status::OK();
 }
 
@@ -4736,9 +4795,6 @@ bool IsCommandExists(const std::string &cmd) {
 void GetCommandList(std::vector<std::string> *cmds) {
   cmds->clear();
   for (const auto &cmd : command_table) {
-    cmds->emplace_back(cmd.first);
-  }
-  for (const auto &cmd : repl_command_table) {
     cmds->emplace_back(cmd.first);
   }
 }

--- a/src/redis_cmd.h
+++ b/src/redis_cmd.h
@@ -55,5 +55,5 @@ class Commander {
 bool IsCommandExists(const std::string &cmd);
 void GetCommandList(std::vector<std::string> *cmds);
 Status LookupCommand(const std::string &cmd_name,
-                     std::unique_ptr<Commander> *cmd, bool is_repl);
+                     std::unique_ptr<Commander> *cmd);
 }  // namespace Redis

--- a/src/redis_connection.h
+++ b/src/redis_connection.h
@@ -19,6 +19,7 @@ class Connection {
     kSlave           = 1 << 4,
     kMonitor         = 1 << 5,
     kCloseAfterReply = 1 << 6,
+    kCloseAsync      = 1 << 7,
   };
 
   explicit Connection(bufferevent *bev, Worker *owner);
@@ -69,6 +70,10 @@ class Connection {
   std::string GetNamespace() { return ns_; }
   void SetNamespace(std::string ns) { ns_ = std::move(ns); }
 
+  void NeedClose() { need_close_ = true; }
+  void NeedNotClose() { need_close_ = false; }
+  bool IsNeedClose() { return need_close_; }
+
   Worker *Owner() { return owner_; }
   int GetFD() { return bufferevent_getfd(bev_); }
   evbuffer *Input() { return bufferevent_get_input(bev_); }
@@ -87,6 +92,7 @@ class Connection {
   std::string addr_;
   int listening_port_ = 0;
   bool is_admin_ = false;
+  bool need_close_ = true;
   std::string last_cmd_;
   time_t create_time_;
   time_t last_interaction_;

--- a/src/redis_request.cc
+++ b/src/redis_request.cc
@@ -161,7 +161,7 @@ void Request::ExecuteCommands(Connection *conn) {
         conn->SetNamespace(kDefaultNamespace);
       }
     }
-    auto s = LookupCommand(cmd_tokens.front(), &conn->current_cmd_, conn->IsRepl());
+    auto s = LookupCommand(cmd_tokens.front(), &conn->current_cmd_);
     if (!s.IsOK()) {
       conn->Reply(Redis::Error("ERR unknown command"));
       continue;

--- a/src/replication.h
+++ b/src/replication.h
@@ -163,9 +163,9 @@ class ReplicationThread {
 
   // Synchronized-Blocking ops
   Status sendAuth(int sock_fd);
-  Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string path,
+  Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string file,
                   uint32_t crc, fetch_file_callback fn);
-  Status fetchFiles(int sock_fd, const std::vector<std::string> &paths,
+  Status fetchFiles(int sock_fd, const std::vector<std::string> &files,
                   const std::vector<uint32_t> &crcs, fetch_file_callback fn);
   Status parallelFetchFile(const std::vector<std::pair<std::string, uint32_t>> &files);
   static bool isRestoringError(const char *err);

--- a/src/replication.h
+++ b/src/replication.h
@@ -27,6 +27,7 @@ enum ReplState {
   kReplError,
 };
 
+typedef std::function<void(const std::string, const uint32_t)> fetch_file_callback;
 
 class FeedSlaveThread {
  public:
@@ -162,7 +163,10 @@ class ReplicationThread {
 
   // Synchronized-Blocking ops
   Status sendAuth(int sock_fd);
-  Status fetchFile(int sock_fd, std::string path, uint32_t crc);
+  Status fetchFile(int sock_fd, evbuffer *evbuf, const std::string path,
+                  uint32_t crc, fetch_file_callback fn);
+  Status fetchFiles(int sock_fd, const std::vector<std::string> &paths,
+                  const std::vector<uint32_t> &crcs, fetch_file_callback fn);
   Status parallelFetchFile(const std::vector<std::pair<std::string, uint32_t>> &files);
   static bool isRestoringError(const char *err);
 

--- a/src/server.h
+++ b/src/server.h
@@ -54,6 +54,9 @@ class Server {
   void cleanupExitedSlaves();
   bool IsSlave() { return !master_host_.empty(); }
   void FeedMonitorConns(Redis::Connection *conn, const std::vector<std::string> &tokens);
+  void IncrFetchFileThread() { fetch_file_threads_num_++; }
+  void DecrFetchFileThread() { fetch_file_threads_num_--; }
+  int GetFetchFileThreadNum() { return fetch_file_threads_num_; }
 
   int PublishMessage(const std::string &channel, const std::string &msg);
   void SubscribeChannel(const std::string &channel, Redis::Connection *conn);
@@ -139,6 +142,7 @@ class Server {
   // slave
   std::mutex slave_threads_mu_;
   std::list<FeedSlaveThread *> slave_threads_;
+  std::atomic<int> fetch_file_threads_num_;
 
   std::mutex db_mu_;
   bool db_compacting_ = false;

--- a/src/util.h
+++ b/src/util.h
@@ -44,6 +44,8 @@ Status SockSetTcpNoDelay(int fd, int val);
 Status SockSetTcpKeepalive(int fd, int interval);
 Status SockSend(int fd, const std::string &data);
 Status SockReadLine(int fd, std::string *data);
+Status SockSendFile(int out_fd, int in_fd, size_t size);
+Status SockSetBlocking(int fd, int blocking);
 int GetPeerAddr(int fd, std::string *addr, uint32_t *port);
 bool IsPortInUse(int port);
 

--- a/tests/tcl/tests/assets/default.conf
+++ b/tests/tcl/tests/assets/default.conf
@@ -1,6 +1,7 @@
 bind 0.0.0.0
 timeout 0
 workers 1
+master-use-repl-port no
 daemonize no
 maxclients 10000
 db-name change.me.db

--- a/tests/tcl/tests/integration/replication.tcl
+++ b/tests/tcl/tests/integration/replication.tcl
@@ -1,0 +1,96 @@
+start_server {tags {"repl"}} {
+    set A [srv 0 client]
+    set A_host [srv 0 host]
+    set A_port [srv 0 port]
+    start_server {} {
+        set B [srv 0 client]
+        set B_host [srv 0 host]
+        set B_port [srv 0 port]
+
+        test {Set instance A as slave of B} {
+            $A slaveof $B_host $B_port
+            wait_for_condition 50 100 {
+                [lindex [$A role] 0] eq {slave} &&
+                [string match {*master_link_status:up*} [$A info replication]]
+            } else {
+                fail "Can't turn the instance into a replica"
+            }
+        }
+    }
+}
+
+start_server {tags {"repl"}} {
+    r set mykey foo
+    r set mystring a
+    r lpush mylist a b c
+    r sadd myset a b c
+    r hmset myhash a 1 b 2 c 3
+    r zadd myzset 1 a 2 b 3 c
+
+    start_server {} {
+        test {Second server should have role master at first} {
+            # Can't statify partial replication
+            for {set i 0} {$i < 1000} {incr i} {
+                r set $i $i
+            }
+            s role
+        } {master}
+
+        test {The role should immediately be changed to "replica"} {
+            r slaveof [srv -1 host] [srv -1 port]
+            s role
+        } {slave}
+        after 1000
+        wait_for_sync r
+        test {Sync should have transferred keys from master} {
+            after 100
+            assert_equal [r -1 get mykey] [r get mykey]
+            assert_equal [r -1 get mystring] [r get mystring]
+            assert_equal [r -1 lrange mylist 0 -1] [r lrange mylist 0 -1]
+            assert_equal [r -1 hgetall myhash] [r hgetall myhash]
+            assert_equal [r -1 zrange myzset 0 -1 WITHSCORES] [r ZRANGE myzset 0 -1 WITHSCORES]
+            assert_equal [r -1 smembers myset] [r smembers myset]
+        }
+        after 10000
+        test {The link status should be up} {
+            s master_link_status
+        } {up}
+
+        test {SET on the master should immediately propagate} {
+            r -1 set mykey bar
+
+            wait_for_condition 500 100 {
+                [r  0 get mykey] eq {bar}
+            } else {
+                fail "SET on master did not propagated on replica"
+            }
+        }
+
+        test {FLUSHALL should replicate} {
+            r -1 flushall
+            after 100
+            r -1 dbsize scan
+            r 0 dbsize scan
+            after 200
+            if {$::valgrind} {after 2000}
+            list [r -1 dbsize] [r 0 dbsize]
+        } {0 0}
+
+        test {ROLE in master reports master with a slave} {
+            set res [r -1 role]
+            lassign $res role offset slaves
+            assert {$role eq {master}}
+            assert {$offset > 0}
+            assert {[llength $slaves] == 1}
+            lassign [lindex $slaves 0] master_host master_port slave_offset
+            assert {$slave_offset <= $offset}
+        }
+
+        test {ROLE in slave reports slave in connected state} {
+            set res [r role]
+            lassign $res role master_host master_port slave_state slave_offset
+            assert {$role eq {slave}}
+            assert {$slave_state eq {connected}}
+        }
+    }
+}

--- a/tests/tcl/tests/integration/replication.tcl
+++ b/tests/tcl/tests/integration/replication.tcl
@@ -40,7 +40,7 @@ start_server {tags {"repl"}} {
             r slaveof [srv -1 host] [srv -1 port]
             s role
         } {slave}
-        after 1000
+
         wait_for_sync r
         test {Sync should have transferred keys from master} {
             after 100
@@ -51,7 +51,7 @@ start_server {tags {"repl"}} {
             assert_equal [r -1 zrange myzset 0 -1 WITHSCORES] [r ZRANGE myzset 0 -1 WITHSCORES]
             assert_equal [r -1 smembers myset] [r smembers myset]
         }
-        after 10000
+
         test {The link status should be up} {
             s master_link_status
         } {up}

--- a/tests/tcl/tests/test_helper.tcl
+++ b/tests/tcl/tests/test_helper.tcl
@@ -31,6 +31,7 @@ set ::all_tests {
     unit/introspection
     unit/limits
     unit/geo
+    integration/replication
 }
 
 # Index to the next test to run in the ::all_tests list.


### PR DESCRIPTION
As we know, in order to implement replication, kvrocks has specified replication threads  that use 'port + 1' as listening port, that may make somethings easy, but it is not convenient to deploy and maintain.

In this PR, kvrocks doesn't use extra port for replication instead of processing replication requests in general work threads. 

Some problems we need to care
**Blocking**
We can't block work threads for processing replication requests. Currently, for replication commands, `_fetch_meta` and `_fetch_file` are blocked, in this commit, we process both commands in new threads.

**Compatibility**
We provide a configuration item `master-use-repl-port` to make new version able to replicate old version master. If the masters are old version, you should set `master-use-repl-port` to yes, otherwise you should set it to no.